### PR TITLE
お知らせの実装とレイアウト微調整

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -372,6 +372,7 @@ def get_question(id):
         question.wrong_option_2 = data.get('wrong_option_2', question.wrong_option_2)
         question.explanation = data.get('explanation', question.explanation)
         # question.explanation_image = data.get('explanation_image', question.explanation_image) S3に保存する
+        question.has_comment = False
 
         db.session.commit()
 

--- a/frontend/src/pages/AdminHome.tsx
+++ b/frontend/src/pages/AdminHome.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
 import { Page } from "../components/layout/Page";
 import { QuestionButton } from "../components/common/QuestionButton";
 import styles from "./Home.module.css";
 
 export const AdminHome = () => {
+  const [quiz, setQuiz] = useState([]);
+  const [loading, setLoading] = useState(true);
   const [userName, setUserName] = useState<string | null>("");
   const navigate = useNavigate();
 
@@ -23,6 +27,30 @@ export const AdminHome = () => {
     }
   }, [navigate]);
 
+  // 確認待ち問題一覧を取得
+  useEffect(() => {
+    const getQuiz = async () => {
+      try {
+        const res = await axios.get(
+          "http://localhost:5000/rarecheck/admin/notaccept/questions",
+          {
+            headers: { "Content-Type": "application/json" },
+            withCredentials: true,
+          },
+        );
+        setQuiz(res.data);
+        setLoading(false); // データ取得後にローディングを終了
+      } catch (error) {
+        console.error("Error fetching data:", error);
+        if (axios.isAxiosError(error)) {
+          console.error("Axios error:", error.response?.data);
+        }
+        setLoading(false); // エラーが発生してもローディングを終了
+      }
+    };
+    getQuiz();
+  }, []);
+
   return (
     <Page login={true}>
       <div className={styles.adminHomeFrame}>
@@ -31,6 +59,13 @@ export const AdminHome = () => {
         </div>
         <div className={styles.noticeLayout}>
           <h3 className={styles.noticeTitle}>お知らせ</h3>
+          {loading ? (
+            <div className={styles.noticeDetail}>loaading...</div>
+          ) : (
+            <div className={styles.noticeDetail}>
+              確認待ちの問題{quiz.length}件
+            </div>
+          )}
         </div>
         <div className={styles.buttonLayout}>
           <div className={styles.buttonArea}>

--- a/frontend/src/pages/Home.module.css
+++ b/frontend/src/pages/Home.module.css
@@ -14,6 +14,7 @@
 .dashboardItem {
   background-color: white;
   border-radius: 3%;
+  padding: 12px 16px;
 }
 
 .exerciseAnalysisLayout {
@@ -31,6 +32,26 @@
   gap: 24px;
   place-content: center;
   padding: 48px;
+}
+
+.rankingDetail {
+  display: flex;
+  justify-content: center;
+  margin: 30%;
+  font-size: 30px;
+}
+
+.userNoticeDetail {
+  margin-top: 30px;
+  margin-left: 27px;
+  margin-right: 27px;
+  color: #05488f;
+  font-size: 27px;
+}
+
+.leftAlignedText {
+  text-align: left;
+  width: 100%;
 }
 
 /* 
@@ -63,6 +84,13 @@
   height: 280px;
   width: 700px;
   border-radius: 3%;
+}
+
+.noticeDetail {
+  margin-top: 30px;
+  margin-left: 27px;
+  color: #05488f;
+  font-size: 27px;
 }
 
 .noticeTitle {

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,5 +1,7 @@
 import { useEffect, useState } from "react";
 import { useNavigate } from "react-router-dom";
+import axios from "axios";
+
 import { Page } from "../components/layout/Page";
 import {
   ExerciseAnalysis,
@@ -8,8 +10,13 @@ import {
 import { fetchExerciseAnalysisData } from "../services/api";
 import styles from "./Home.module.css";
 import { QuestionButtonArea } from "../components/QuestionButtonArea";
+import { Typography } from "@mui/material";
+import EngineeringIcon from "@mui/icons-material/Engineering";
+import { GetCreatedList } from "../types/api/GetCreatedList";
 
 export const Home = () => {
+  const [createdQuiz, setCreatedQuiz] = useState<GetCreatedList[]>([]);
+  const [loading, setLoading] = useState(true);
   const [userName, setUserName] = useState<string | null>("");
   const [exerciseAnalysisData, setExerciseAnalysisData] =
     useState<ExerciseAnalysisData | null>(null);
@@ -50,6 +57,33 @@ export const Home = () => {
     fetchData();
   }, [navigate]);
 
+  // 作成済み問題一覧を取得
+  useEffect(() => {
+    const getQuiz = async () => {
+      try {
+        const res = await axios.get(
+          "http://localhost:5000/rarecheck/users/questions",
+          {
+            headers: { "Content-Type": "application/json" },
+            withCredentials: true,
+          },
+        );
+        setCreatedQuiz(res.data);
+        setLoading(false); // データ取得後にローディングを終了
+      } catch (error) {
+        console.error("Error fetching data:", error);
+        if (axios.isAxiosError(error)) {
+          console.error("Axios error:", error.response?.data);
+        }
+        setLoading(false); // エラーが発生してもローディングを終了
+      }
+    };
+    getQuiz();
+  }, []);
+
+  const commentCount = createdQuiz.filter((quiz) => quiz.has_comment).length;
+  const hasComment = commentCount > 0 ? true : false;
+
   return (
     <Page login={true}>
       <div className={styles.dashboadLayout}>
@@ -69,7 +103,15 @@ export const Home = () => {
             gridRow: "1 / 7",
           }}
         >
-          ランキング
+          <Typography variant="h6" className={styles.leftAlignedText}>
+            ランキング
+          </Typography>
+          <div className={styles.rankingDetail}>
+            <div>
+              工事中
+              <EngineeringIcon sx={{ fontSize: 40 }} />
+            </div>
+          </div>
         </div>
         <div
           className={styles.dashboardItem}
@@ -78,7 +120,18 @@ export const Home = () => {
             gridRow: "2 / 7",
           }}
         >
-          お知らせ
+          <Typography variant="h6" className={styles.leftAlignedText}>
+            お知らせ
+          </Typography>
+          {loading && <div className={styles.userNoticeDetail}>loading...</div>}
+          {hasComment ? (
+            <div className={styles.userNoticeDetail}>
+              作成した問題にコメントがあります！（
+              {commentCount}件）
+            </div>
+          ) : (
+            <div className={styles.userNoticeDetail}>お知らせはありません</div>
+          )}
         </div>
         <div
           className={`${styles.dashboardItem} ${styles.exerciseAnalysisLayout}`}


### PR DESCRIPTION
管理者ホーム画面と受講者ホーム画面のお知らせが表示されるようにしました。また、ホーム画面（受講生）のレイアウトを微修正、ランキングは工事中にしました。

また取り急ぎ、”受講生のお知らせの件数”と、”作成済み問題一覧のコメントあり/なし”は、has_commentの真偽値で判断することとし、app.pyの問題編集（受講生）を修正しました。管理者からのコメントを踏まえ問題を編集したら、has_commentがfalseとなる、つまり"コメントがなし"になるようにしています。